### PR TITLE
qa: normalize `laminas/laminas-component-installer` configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "extra": {
-        "zf": {
+        "laminas": {
             "config-provider": "WShafer\\Mezzio\\Symfony\\Router\\ConfigProvider"
         }
     }


### PR DESCRIPTION
Due to the migration policy, `laminas/laminas-component-installer` also reads `zf` keys from `composer.extra`. This will be removed in later major versions of that component. To ensure, this package will remain compatible with the `laminas/laminas-component-installer`, `composer.extra.laminas` has to be provided.